### PR TITLE
Add option to train pipnet on funnybirds

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - tensorflow-datasets
   - pip:
     - opencv-contrib-python
-    - --extra-index-url https://download.pytorch.org/whl/cu118
-    - torch==2.0.1+cu118
-    - torchvision==0.15.2+cu118
+    - --extra-index-url https://download.pytorch.org/whl/cu121
+    - torch==2.2.1+cu121
+    - torchvision==0.17.1+cu121
     - torchinfo

--- a/src/data/config.py
+++ b/src/data/config.py
@@ -1,20 +1,20 @@
-import os
+from pathlib import Path
 
 from utils.environment import get_env
 
 DATASETS = {}
 
-data_dir = os.path.join(get_env("DATA_ROOT"), "CUB_200", "dataset")
+data_dir = Path(get_env("DATA_ROOT"), "CUB_200", "dataset")
 DATASETS["CUB-200-2011"] = {
     "img_shape": (224, 224),
     "num_classes": 200,
     "num_prototypes_per_class": 10,
     "color_channels": 3,
     "data_dir": data_dir,
-    "train_dir": os.path.join(data_dir, "train_crop"),
-    "train_dir_projection": os.path.join(data_dir, "train_full"),
-    "test_dir": os.path.join(data_dir, "test_crop"),
-    "test_dir_projection": os.path.join(data_dir, "test_full"),
+    "train_dir": data_dir / "train_crop",
+    "train_dir_projection": data_dir / "train_full",
+    "test_dir": data_dir / "test_crop",
+    "test_dir_projection": data_dir / "test_full",
     "image_folders": True,
     "mean": (0.485, 0.456, 0.406),
     "std": (0.229, 0.224, 0.225),
@@ -22,17 +22,17 @@ DATASETS["CUB-200-2011"] = {
 }
 
 
-data_dir = os.path.join(get_env("DATA_ROOT"), "CUB_200", "small")
+data_dir = Path(get_env("DATA_ROOT"), "CUB_200", "small")
 DATASETS["CUB-10"] = {
     "img_shape": (224, 224),
     "num_classes": 10,
     "num_prototypes_per_class": 10,
     "color_channels": 3,
     "data_dir": data_dir,
-    "train_dir": os.path.join(data_dir, "train_crop"),
-    "train_dir_projection": os.path.join(data_dir, "train_full"),
-    "test_dir": os.path.join(data_dir, "test_crop"),
-    "test_dir_projection": os.path.join(data_dir, "test_full"),
+    "train_dir": data_dir / "train_crop",
+    "train_dir_projection": data_dir / "train_full",
+    "test_dir": data_dir / "test_crop",
+    "test_dir_projection": data_dir / "test_full",
     "image_folders": True,
     "mean": (0.485, 0.456, 0.406),
     "std": (0.229, 0.224, 0.225),
@@ -40,30 +40,62 @@ DATASETS["CUB-10"] = {
 }
 
 
-data_dir = os.path.join(get_env("DATA_ROOT"), "MNIST", "ImageFolders")
+data_dir = Path(get_env("DATA_ROOT"), "FunnyBirds")
+DATASETS["Funny"] = {
+    "img_shape": (256, 256),
+    "num_classes": 50,
+    "num_prototypes_per_class": 50,
+    "color_channels": 3,
+    "data_dir": data_dir,
+    "train_dir": data_dir / "train",
+    "test_dir": data_dir / "test",
+    "image_folders": True,
+    "mean": (0.485, 0.456, 0.406),
+    "std": (0.229, 0.224, 0.225),
+    "augm": True,
+}
+
+
+data_dir = Path(get_env("DATA_ROOT"), "FunnyBirds", "small")
+DATASETS["Funny-10"] = {
+    "img_shape": (256, 256),
+    "num_classes": 10,
+    "num_prototypes_per_class": 50,
+    "color_channels": 3,
+    "data_dir": data_dir,
+    "train_dir": data_dir / "train",
+    "test_dir": data_dir / "test",
+    "image_folders": True,
+    "mean": (0.485, 0.456, 0.406),
+    "std": (0.229, 0.224, 0.225),
+    "augm": True,
+}
+
+
+data_dir = Path(get_env("DATA_ROOT"), "MNIST", "ImageFolders")
 DATASETS["MNIST"] = {
     "img_shape": (32, 32),
     "num_classes": 10,
     "num_prototypes_per_class": 10,
     "color_channels": 1,
     "data_dir": data_dir,
-    "train_dir": os.path.join(data_dir, "train"),
-    "test_dir": os.path.join(data_dir, "test"),
+    "train_dir": data_dir / "train",
+    "test_dir": data_dir / "test",
     "image_folders": True,
     "augm": False,
 }
 
 
-data_dir = os.path.join(get_env("DATA_ROOT"), "pascal_voc")
+data_dir = Path(get_env("DATA_ROOT"), "pascal_voc")
 DATASETS["pascal_voc"] = {
     "img_shape": (224, 224),
     "num_classes": 20,
     "num_prototypes_per_class": 10,
     "color_channels": 3,
     "data_dir": data_dir,
-    "train_push_dir": os.path.join(data_dir, "train_4"),
-    "train_dir": os.path.join(data_dir, "train_4"),
-    "test_dir": os.path.join(data_dir, "test_4"),
+    "train_push_dir": data_dir / "train_4",
+    "train_dir": data_dir / "train_4",
+    "test_dir": data_dir / "test_4",
     "mean": (0.4592, 0.4360, 0.4035),
     "std": (0.2704, 0.2669, 0.2792),
     "image_folders": True,

--- a/src/models/PIPNet/util/data.py
+++ b/src/models/PIPNet/util/data.py
@@ -248,7 +248,7 @@ def get_transforms(args: argparse.Namespace):
     if dataset_config["augm"]:
         # transform1: first step of augmentation
         match args.dataset:
-            case "CUB-200-2011" | "CUB-10":
+            case "CUB-200-2011" | "CUB-10" | "Funny" | "Funny-10":
                 transform1 = transforms.Compose(
                     [
                         transforms.Resize(size=(img_shape[0] + 8, img_shape[1] + 8)),
@@ -277,7 +277,7 @@ def get_transforms(args: argparse.Namespace):
 
         # transform1p: alternative for transform1 during pretrain
         match args.dataset:
-            case "CUB-200-2011" | "CUB-10":
+            case "CUB-200-2011" | "CUB-10" | "Funny" | "Funny-10":
                 transform1p = transforms.Compose(
                     [
                         transforms.Resize(

--- a/src/models/PIPNet/util/data.py
+++ b/src/models/PIPNet/util/data.py
@@ -232,7 +232,7 @@ def get_transforms(args: argparse.Namespace):
 
     mean = dataset_config["mean"]
     std = dataset_config["std"]
-    img_shape = dataset_config["img_shape"]
+    img_shape = tuple(args.image_size)
 
     normalize = transforms.Normalize(mean=mean, std=std)
 

--- a/src/models/PIPNet/util/data.py
+++ b/src/models/PIPNet/util/data.py
@@ -293,7 +293,7 @@ def get_transforms(args: argparse.Namespace):
                     ]
                 )
             case _:
-                transform1p = None
+                transform1p = transform_no_augment
 
         # transform2: second step of augmentation
         # applied twice on the result of transform1(p) to obtain two similar imgs
@@ -308,7 +308,7 @@ def get_transforms(args: argparse.Namespace):
         )
     else:
         transform1 = transform_no_augment
-        transform1p = None
+        transform1p = transform_no_augment
         transform2 = transform_no_augment
 
     return (

--- a/src/models/PIPNet/util/data.py
+++ b/src/models/PIPNet/util/data.py
@@ -239,7 +239,7 @@ def get_transforms(args: argparse.Namespace):
     transform_no_augment = transforms.Compose(
         [
             transforms.Resize(size=img_shape),
-            transforms.ToImageTensor(),
+            transforms.ToImage(),
             transforms.ConvertImageDtype(),
             normalize,
         ]
@@ -301,7 +301,7 @@ def get_transforms(args: argparse.Namespace):
             [
                 TrivialAugmentWideNoShape(),
                 transforms.RandomCrop(size=img_shape),  # includes crop
-                transforms.ToImageTensor(),
+                transforms.ToImage(),
                 transforms.ConvertImageDtype(),
                 normalize,
             ]


### PR DESCRIPTION
Solving issue: #11 

By setting `--dataset Funny` a model will be trained on the FunnyBirds dataset. For testing purposes, a smaller version of the dataset was created (by keeping 10 random classes), named `Funny-10`.

- CUDA was upgraded: `11.8` &rarr;  `12.4`
- added dataset details in `src/data/config.py`
- set augmentation in `src/models/PIPNet/util/data.py`